### PR TITLE
Switched to Node.js 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -33,5 +33,5 @@ inputs:
     default: 'false'
     required: false
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
Because NodeJs 12 is deprecated
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/